### PR TITLE
1.3.0 Adição de configuração para habilitar debug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: '1.2.4' # // TODO caso necessário definir a tag da release manualmente
+        custom_tag: '1.3.0' # // TODO caso necessário definir a tag da release manualmente
 
     # Generate new release
     - name: Generate new Release

--- a/Admin/LknmpGatewayGiveWPAdmin.php
+++ b/Admin/LknmpGatewayGiveWPAdmin.php
@@ -140,6 +140,18 @@ final class LknmpGatewayGiveWPAdmin
                 );
 
                 $settings[] = array(
+                    'name' => __('Debug Mode', 'lknmp-gateway-givewp'),
+                    'id' => 'mercado_pago_debug',
+                    'desc' => __('Enable Debug environment.' , 'lknmp-gateway-givewp') . '<a id="lkn-give-debug">' . __('See logs.' , 'lknmp-gateway-givewp') . '</a>',
+                    'type' => 'radio',
+                    'default' => 'disabled',
+                    'options' => array(
+                        'enabled' => __('Enable', 'lknmp-gateway-givewp'),
+                        'disabled' => __('Disable', 'lknmp-gateway-givewp'),
+                    ),
+                );
+
+                $settings[] = array(
                     'name' => __('Advanced Debug Mode', 'lknmp-gateway-givewp'),
                     'id' => 'mercado_pago_advanced_debug',
                     'desc' => __('Enable advanced Debug environment (CONSOLE - JAVASCRIPT). Be careful enabling this option will leave your site vulnerable.', 'lknmp-gateway-givewp'),

--- a/Admin/js/lknmp-gateway-givewp-show-message.js
+++ b/Admin/js/lknmp-gateway-givewp-show-message.js
@@ -2,6 +2,12 @@ document.addEventListener("DOMContentLoaded", () => {
     if (window.location.href === varsPhp.admin_url) {
         initialize();
     }
+    let logBtn = document.getElementById('lkn-give-debug');
+    if(logBtn){
+        let logsUrl = wpApiSettings.root.replace('/wp-json/', '/wp-admin/edit.php?post_type=give_forms&page=give-tools&tab=logs');
+        logBtn.setAttribute('href', logsUrl);
+        logBtn.setAttribute('target', '_blank');
+    }
 });
 
 function initialize() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.0 - 08/01/2025
+* Adição de configuração para habilitar debug.
+
 # 1.2.4 - 26/11/2024
 * Correção em url de redirecionamento.
 * Melhoria no fluxo de pagamento.

--- a/Public/LknmpGatewayGiveWPGateway.php
+++ b/Public/LknmpGatewayGiveWPGateway.php
@@ -112,6 +112,16 @@ final class LknmpGatewayGiveWPGateway extends PaymentGateway
             $idTeste = $gatewayData['gatewayId'];
             add_option("lknmp_gateway_" . $idTeste, $donation->id);
 
+            LknmpGatewayGiveWPHelper::regLog(
+                'info', // logType
+                'createPayment', // category
+                'Criar pagamento', // description
+                array(
+                    'donation' => $donation->id,
+                    'gatewayData' => $gatewayData
+                )
+            );
+
             $donation->status = DonationStatus::PENDING();
             $donation->save();
 

--- a/Public/LknmpGatewayGiveWPPublic.php
+++ b/Public/LknmpGatewayGiveWPPublic.php
@@ -115,7 +115,7 @@ final class LknmpGatewayGiveWPPublic {
                 'MenssageErrorNameEmpty' => $MenssageErrorNameEmpty,
                 'MenssageErrorName' => $MenssageErrorName,
                 'MenssageErrorEmailEmpty' => $MenssageErrorEmailEmpty,
-                'MenssageErrorEmailInvalid' => $$MenssageErrorEmailInvalid,
+                'MenssageErrorEmailInvalid' => $MenssageErrorEmailInvalid,
             ),
         );
 

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/givewp/
 Tags: givewp, payment, mercadopago, card
 Requires at least: 5.7
 Tested up to: 6.7
-Stable tag: 1.2.4
+Stable tag: 1.3.0
 Requires PHP: 7.4
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -83,6 +83,9 @@ The Link Nacional MercadoPago for GiveWP plugin is now live and working.
 1. Nothing yet.
 
 == Changelog ==
+
+= 1.3.0 = *2025/01/08*
+* Add configuration to enable debug.
 
 = 1.2.4 = *2024/11/26*
 * Fixed redirect URL.

--- a/languages/lknmp-mercadopago-for-givewp-pt_BR.po
+++ b/languages/lknmp-mercadopago-for-givewp-pt_BR.po
@@ -76,3 +76,12 @@ msgstr "Pagamento em processo, feche a guia atual e siga o procedimento de pagam
 
 msgid "Mercado Pago is not enabled for the classic and multistep form!"
 msgstr "Mercado Pago não está habilitado para o formulário clássico e multistep!"
+
+msgid "Debug Mode"
+msgstr "Modo de Depuração"
+
+msgid "Enable Debug environment."
+msgstr "Habilitar ambiente de depuração."
+
+msgid "See logs."
+msgstr "Ver logs."

--- a/languages/lknmp-mercadopago-for-givewp.pot
+++ b/languages/lknmp-mercadopago-for-givewp.pot
@@ -76,3 +76,12 @@ msgstr ""
 
 msgid "Mercado Pago is not enabled for the classic and multistep form!"
 msgstr ""
+
+msgid "Debug Mode"
+msgstr ""
+
+msgid "Enable Debug environment."
+msgstr ""
+
+msgid "See logs."
+msgstr ""

--- a/lknmp-gateway-givewp.php
+++ b/lknmp-gateway-givewp.php
@@ -12,10 +12,10 @@
  * @package           LKNMP_Mercadopago_For_Givewp
  *
  * @wordpress-plugin
- * Plugin Name:       Link Nacional Payment Gateway for MercadoPago and GiveWP
- * Requires Plugins: give
+ * Plugin Name:       Mercado Pago para Give
+ * Requires Plugins:  give
  * Plugin URI:        https://www.linknacional.com.br/wordpress/givewp/
- * Description:       MercadoPago Payment Gateway for GiveWP donation plugin for WordPress.
+ * Description:       Gateway de pagamento Mercado Pago integrado ao plugin de doações GiveWP no WordPress.
  * Version:           1.2.4
  * Author:            Link Nacional
  * Author URI:        https://www.linknacional.com.br/wordpress/givewp//

--- a/lknmp-gateway-givewp.php
+++ b/lknmp-gateway-givewp.php
@@ -16,7 +16,7 @@
  * Requires Plugins:  give
  * Plugin URI:        https://www.linknacional.com.br/wordpress/givewp/
  * Description:       Gateway de pagamento Mercado Pago integrado ao plugin de doações GiveWP no WordPress.
- * Version:           1.2.4
+ * Version:           1.3.0
  * Author:            Link Nacional
  * Author URI:        https://www.linknacional.com.br/wordpress/givewp//
  * License:           GPL-3.0+
@@ -42,7 +42,7 @@ use Lknmp\Gateway\Includes\LknmpGatewayGiveWPDeactivator;
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('LKNMP_GATEWAY_GIVEWP_VERSION')) {
-    define('LKNMP_GATEWAY_GIVEWP_VERSION', '1.2.4');
+    define('LKNMP_GATEWAY_GIVEWP_VERSION', '1.3.0');
 }
 
 if (! defined('LKNMP_GATEWAY_MIN_GIVE_VERSION')) {


### PR DESCRIPTION
- Adição de configuração para habilitar debug.
>Uma configuração foi adicionada para habilitar o modo debug, permitindo a exibição de logs das transações na página de logs do GiveWP.
![image](https://github.com/user-attachments/assets/885536b2-e80d-40fa-86fa-0b61889cf3fb)
