### PR TITLE
1.3.1 - lkn-mercadopago-for-givewp (Erro formatação dos valores checkout ) 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: '1.3.0' # // TODO caso necessário definir a tag da release manualmente
+        custom_tag: '1.3.1' # // TODO caso necessário definir a tag da release manualmente
 
     # Generate new release
     - name: Generate new Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.3.1 - 10/03/2025
+# 1.3.1 - 12/03/2025
 * Correção na conversão do valor para float.
 
 # 1.3.0 - 08/01/2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.1 - 10/03/2025
+* Correção na conversão do valor para float.
+
 # 1.3.0 - 08/01/2025
 * Adição de configuração para habilitar debug.
 

--- a/Public/js/lknmp-gateway-givewp-public.js
+++ b/Public/js/lknmp-gateway-givewp-public.js
@@ -48,7 +48,8 @@
 				console.log(valorText);
 			}
 
-			let amount = valorText
+			const valorFormatado = await valorText.replace(/[^\d.,]/g, '').replace(/\./g, '').replace(',', '.')
+			let amount = valorFormatado
 
 			if (lknmpGlobals.advDebug == 'enabled') {
 				console.log(amount)

--- a/Public/js/plugin-script.js
+++ b/Public/js/plugin-script.js
@@ -16,7 +16,7 @@ function renderComponentsOnce() {
                     const mp = new MercadoPago(configData.key);
                     //TODO se houver erro 400, temos que retornar ao usuário???
                     const bricksBuilder = mp.bricks();
-                    mp.bricks().create("wallet", "wallet_container", {
+                    mp?.bricks().create("wallet", "wallet_container", {
                         initialization: {
                             preferenceId: preferenceID,
                             redirectMode: 'blank'
@@ -85,7 +85,8 @@ async function criarPreferenciaDePagamento() {
         valorText = document.querySelector('.givewp-elements-donationSummary__list__item__value').textContent;
     }
 
-    const valorNumerico = parseFloat(valorText.replace(/[^\d.,]/g, ''));
+    const valorFormatado = await valorText.replace(/[^\d.,]/g, '').replace(/\./g, '').replace(',', '.')
+    const valorNumerico = parseFloat(valorFormatado);
 
     if (configData.advDebug == 'enabled') {
         console.log(valorNumerico)
@@ -213,7 +214,7 @@ function observeDonationChanges() {
 
                 const nomeInput = document.querySelector('input[name="firstName"]');
                 const emailInput = document.querySelector('input[name="email"]');
-                const oldButton = document.querySelector('#wallet_container');
+                const oldButton = document.getElementById('wallet_container');
 
                 if (oldButton) {
                     oldButton.remove();
@@ -281,7 +282,7 @@ function observeFormChanges() {
 function checkInputs() {
     const nomeInput = document.querySelector('input[name="firstName"]');
     const emailInput = document.querySelector('input[name="email"]');
-    const walletContainer = document.querySelector('#wallet_container');
+    const walletContainer = document.getElementById('wallet_container');
     let warningText = document.querySelector('#warning-text');
 
     function isValidEmail(email) {
@@ -396,7 +397,7 @@ const LknmpGatewayGiveWP = {
                 //observeButtonChanges já está cumprindo a função de recarregar o formulário
                 updateDonationAmount();
 
-                const oldButton = document.querySelector('#wallet_container');
+                const oldButton = document.getElementById('wallet_container');
                 if (oldButton) {
                     oldButton.remove();
                 }

--- a/README.txt
+++ b/README.txt
@@ -84,7 +84,7 @@ The Link Nacional MercadoPago for GiveWP plugin is now live and working.
 
 == Changelog ==
 
-= 1.3.1 = *2025/03/01*
+= 1.3.1 = *2025/03/12*
 * Fix in the conversion of the value to float.
 
 = 1.3.0 = *2025/01/08*

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/givewp/
 Tags: givewp, payment, mercadopago, card
 Requires at least: 5.7
 Tested up to: 6.7
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 Requires PHP: 7.4
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/README.txt
+++ b/README.txt
@@ -84,6 +84,9 @@ The Link Nacional MercadoPago for GiveWP plugin is now live and working.
 
 == Changelog ==
 
+= 1.3.1 = *2025/03/01*
+* Fix in the conversion of the value to float.
+
 = 1.3.0 = *2025/01/08*
 * Add configuration to enable debug.
 

--- a/lknmp-gateway-givewp.php
+++ b/lknmp-gateway-givewp.php
@@ -16,7 +16,7 @@
  * Requires Plugins:  give
  * Plugin URI:        https://www.linknacional.com.br/wordpress/givewp/
  * Description:       Gateway de pagamento Mercado Pago integrado ao plugin de doações GiveWP no WordPress.
- * Version:           1.3.0
+ * Version:           1.3.1
  * Author:            Link Nacional
  * Author URI:        https://www.linknacional.com.br/wordpress/givewp//
  * License:           GPL-3.0+
@@ -42,7 +42,7 @@ use Lknmp\Gateway\Includes\LknmpGatewayGiveWPDeactivator;
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('LKNMP_GATEWAY_GIVEWP_VERSION')) {
-    define('LKNMP_GATEWAY_GIVEWP_VERSION', '1.3.0');
+    define('LKNMP_GATEWAY_GIVEWP_VERSION', '1.3.1');
 }
 
 if (! defined('LKNMP_GATEWAY_MIN_GIVE_VERSION')) {


### PR DESCRIPTION
# Link Nacional MercadoPago Payment Gateway for GiveWP

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: givewp, payment, mercadopago, card

Testado até: 6.7

Versão estável: 1.3.1

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil)

## Descrição

O [MercadoPago Payment Gateway for GiveWP](https://www.linknacional.com.br/wordpress/givewp/) integra perfeitamente o MercadoPago com o plugin de doações GiveWP para WordPress, fornecendo uma solução segura e eficiente para receber doações online. Este plugin suporta múltiplos métodos de pagamento, doações recorrentes e formulários de doação personalizáveis. Melhore a experiência dos seus doadores com um gateway de pagamento confiável, aumente seus esforços de arrecadação de fundos e gerencie as doações de forma simples com relatórios detalhados e uma interface amigável.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin GiveWP também está ativado.

## Resumo(1.3.1):

> Correção na conversão do valor no momento do pagamento:

*Antigo*: 5.000 -> 5.
*Atual*: 5.000 -> 5000.
