### PR TITLE
1.4.0 - lkn-mercadopago-for-givewp (Páginas de feedback para o sandbox de pagamento)

### DIFF
--- a/Includes/LknmpGatewayGiveWP.php
+++ b/Includes/LknmpGatewayGiveWP.php
@@ -308,6 +308,7 @@ final class LknmpGatewayGiveWP
                                 background-color: #e8f5e9;
                                 border: 1px solid #c8e6c9;
                                 border-radius: 8px;
+                                max-width: 500px;
                                 box-shadow: 0 4px 8px rgba(0,0,0,0.1);
                             }
                             h1 {
@@ -378,6 +379,7 @@ final class LknmpGatewayGiveWP
                                 background-color: #ffebee;
                                 border: 1px solid #ffcdd2;
                                 border-radius: 8px;
+                                max-width: 500px;
                                 box-shadow: 0 4px 8px rgba(0,0,0,0.1);
                             }
                             h1 {
@@ -450,6 +452,7 @@ final class LknmpGatewayGiveWP
                                 background-color: #ffecb3;
                                 border: 1px solid #ffe082;
                                 border-radius: 8px;
+                                max-width: 500px;
                                 box-shadow: 0 4px 8px rgba(0,0,0,0.1);
                             }
                             h1 {

--- a/Includes/LknmpGatewayGiveWP.php
+++ b/Includes/LknmpGatewayGiveWP.php
@@ -280,7 +280,12 @@ final class LknmpGatewayGiveWP
                 $receipt_id = give_get_payment_meta($donation_id, '_give_payment_purchase_key');
                 $redirect_url = home_url('/?givewp-route=donation-confirmation-receipt-view&receipt-id=' . sanitize_text_field($receipt_id));
 
-                header("Location: $redirect_url", true, 302);
+                setcookie('lkn_payment_url', $redirect_url, time() + 3600, '/');
+
+                return wp_send_json_success(array(
+                    'status' => true,
+                    'message' => 'Payment processed successfully'
+                ));
                 exit;
                 break;
             case '2':
@@ -300,7 +305,12 @@ final class LknmpGatewayGiveWP
                 $receipt_id = give_get_payment_meta($donation_id, '_give_payment_purchase_key');
                 $redirect_url = home_url('/?givewp-route=donation-confirmation-receipt-view&receipt-id=' . sanitize_text_field($receipt_id));
 
-                header("Location: $redirect_url", true, 302);
+                setcookie('lkn_payment_url', $redirect_url, time() + 3600, '/');
+
+                return wp_send_json_success(array(
+                    'status' => true,
+                    'message' => 'Payment processing failed'
+                ));
                 exit;
                 break;
             case '3':
@@ -319,14 +329,15 @@ final class LknmpGatewayGiveWP
                     return new WP_Error('save_failed', 'Failed to update donation status', array('status' => 500));
                 }
 
-                $response_data = array(
-                    'id' => $id,
-                    'donation_id' => $donation_id,
-                );
+                $receipt_id = give_get_payment_meta($donation_id, '_give_payment_purchase_key');
+                $redirect_url = home_url('/?givewp-route=donation-confirmation-receipt-view&receipt-id=' . sanitize_text_field($receipt_id));
 
-                $url_pagina = give_get_failed_transaction_uri();
+                setcookie('lkn_payment_url', 'success', time() + 3600, '/');
 
-                header("Location: $url_pagina", true, 302);
+                return wp_send_json_success(array(
+                    'status' => true,
+                    'message' => 'Payment error'
+                ));
                 exit;
                 break;
             default:

--- a/Includes/LknmpGatewayGiveWP.php
+++ b/Includes/LknmpGatewayGiveWP.php
@@ -282,10 +282,55 @@ final class LknmpGatewayGiveWP
 
                 setcookie('lkn_payment_url', $redirect_url, time() + 3600, '/');
 
-                return wp_send_json_success(array(
-                    'status' => true,
-                    'message' => 'Payment processed successfully'
-                ));
+                header('Content-Type: text/html');
+
+                $html = '
+                    <!DOCTYPE html>
+                    <html lang="pt-BR">
+                    <head>
+                        <meta charset="UTF-8">
+                        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                        <title>Pagamento Concluído</title>
+                        <style>
+                            body {
+                                display: flex;
+                                justify-content: center;
+                                align-items: center;
+                                height: 100vh;
+                                background-color: #f9f9f9;
+                                font-family: Arial, sans-serif;
+                                margin: 0;
+                                color: #333;
+                            }
+                            .message {
+                                text-align: center;
+                                padding: 20px;
+                                background-color: #e8f5e9;
+                                border: 1px solid #c8e6c9;
+                                border-radius: 8px;
+                                box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+                            }
+                            h1 {
+                                color: #4caf50;
+                                font-size: 24px;
+                                margin-bottom: 10px;
+                            }
+                            p {
+                                font-size: 18px;
+                                margin-bottom: 20px;
+                            }
+                        </style>
+                    </head>
+                    <body>
+                        <div class="message">
+                            <h1>✅ Pagamento realizado com sucesso!</h1>
+                            <p>Seu pagamento foi processado com sucesso. Você pode fechar esta guia ou retornar para a página anterior para verificar os detalhes da transação.</p>
+                        </div>
+                    </body>
+                    </html>
+                ';
+                echo $html;
+
                 exit;
                 break;
             case '2':
@@ -307,10 +352,55 @@ final class LknmpGatewayGiveWP
 
                 setcookie('lkn_payment_url', $redirect_url, time() + 3600, '/');
 
-                return wp_send_json_success(array(
-                    'status' => true,
-                    'message' => 'Payment processing failed'
-                ));
+                header('Content-Type: text/html');
+
+                $html = '
+                    <!DOCTYPE html>
+                    <html lang="pt-BR">
+                    <head>
+                        <meta charset="UTF-8">
+                        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                        <title>Pagamento Falhou</title>
+                        <style>
+                            body {
+                                display: flex;
+                                justify-content: center;
+                                align-items: center;
+                                height: 100vh;
+                                background-color: #fdf3f3;
+                                font-family: Arial, sans-serif;
+                                margin: 0;
+                                color: #333;
+                            }
+                            .message {
+                                text-align: center;
+                                padding: 20px;
+                                background-color: #ffebee;
+                                border: 1px solid #ffcdd2;
+                                border-radius: 8px;
+                                box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+                            }
+                            h1 {
+                                color: #f44336;
+                                font-size: 24px;
+                                margin-bottom: 10px;
+                            }
+                            p {
+                                font-size: 18px;
+                                margin-bottom: 20px;
+                            }
+                        </style>
+                    </head>
+                    <body>
+                        <div class="message">
+                            <h1>❌ O pagamento não foi concluído</h1>
+                            <p>Ocorreu um problema ao processar seu pagamento. Retorne para a página anterior para verificar o resumo da transação e tentar novamente.</p>
+                        </div>
+                    </body>
+                    </html>
+                ';
+
+                echo $html;
                 exit;
                 break;
             case '3':
@@ -334,10 +424,54 @@ final class LknmpGatewayGiveWP
 
                 setcookie('lkn_payment_url', 'success', time() + 3600, '/');
 
-                return wp_send_json_success(array(
-                    'status' => true,
-                    'message' => 'Payment error'
-                ));
+                header('Content-Type: text/html');
+
+                $html = '
+                    <!DOCTYPE html>
+                    <html lang="pt-BR">
+                    <head>
+                        <meta charset="UTF-8">
+                        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                        <title>Erro no Pagamento</title>
+                        <style>
+                            body {
+                                display: flex;
+                                justify-content: center;
+                                align-items: center;
+                                height: 100vh;
+                                background-color: #fff8e1;
+                                font-family: Arial, sans-serif;
+                                margin: 0;
+                                color: #333;
+                            }
+                            .message {
+                                text-align: center;
+                                padding: 20px;
+                                background-color: #ffecb3;
+                                border: 1px solid #ffe082;
+                                border-radius: 8px;
+                                box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+                            }
+                            h1 {
+                                color: #ff9800;
+                                font-size: 24px;
+                                margin-bottom: 10px;
+                            }
+                            p {
+                                font-size: 18px;
+                                margin-bottom: 20px;
+                            }
+                        </style>
+                    </head>
+                    <body>
+                        <div class="message">
+                            <h1>⚠️ Erro no processamento do pagamento</h1>
+                            <p>Ocorreu um erro durante o processamento do pagamento. Tente novamente ou entre em contato com o suporte.</p>
+                        </div>
+                    </body>
+                    </html>
+                ';
+                echo $html;
                 exit;
                 break;
             default:

--- a/Public/LknmpGatewayGiveWPGateway.php
+++ b/Public/LknmpGatewayGiveWPGateway.php
@@ -125,6 +125,11 @@ final class LknmpGatewayGiveWPGateway extends PaymentGateway
             $donation->status = DonationStatus::PENDING();
             $donation->save();
 
+            $receipt_id = give_get_payment_meta($donation->id, '_give_payment_purchase_key');
+            $redirect_url = home_url('/?givewp-route=donation-confirmation-receipt-view&receipt-id=' . sanitize_text_field($receipt_id));
+
+            header("Location: $redirect_url", true, 302);
+
             //return new PaymentPending();
             return wp_send_json_success(['status' => 'pending', 'message' => 'Pagamento está pendente.']);
             // return new GatewayCommand();

--- a/Public/LknmpGatewayGiveWPPublic.php
+++ b/Public/LknmpGatewayGiveWPPublic.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Lknmp\Gateway\PublicView;
 
 use Lknmp\Gateway\Includes\LknmpGatewayGiveWPHelper;
@@ -23,7 +24,8 @@ use Lknmp\Gateway\Includes\LknmpGatewayGiveWPHelper;
  * @subpackage Lknmp_Gateway_Givewp/public
  * @author     Link Nacional <contato@linknacional>
  */
-final class LknmpGatewayGiveWPPublic {
+final class LknmpGatewayGiveWPPublic
+{
     /**
      * The ID of this plugin.
      *
@@ -49,7 +51,8 @@ final class LknmpGatewayGiveWPPublic {
      * @param      string    $plugin_name       The name of the plugin.
      * @param      string    $version    The version of this plugin.
      */
-    public function __construct( $plugin_name, $version ) {
+    public function __construct($plugin_name, $version)
+    {
         $this->plugin_name = $plugin_name;
         $this->version = $version;
     }
@@ -59,7 +62,8 @@ final class LknmpGatewayGiveWPPublic {
      *
      * @since    1.0.0
      */
-    public function enqueue_styles(): void {
+    public function enqueue_styles(): void
+    {
         /**
          * This function is provided for demonstration purposes only.
          *
@@ -71,7 +75,7 @@ final class LknmpGatewayGiveWPPublic {
          * between the defined hooks and the functions defined in this
          * class.
          */
-        wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/lknmp-gateway-givewp-public.css', array(), $this->version, 'all' );
+        wp_enqueue_style($this->plugin_name, plugin_dir_url(__FILE__) . 'css/lknmp-gateway-givewp-public.css', array(), $this->version, 'all');
     }
 
     /**
@@ -79,7 +83,8 @@ final class LknmpGatewayGiveWPPublic {
      *
      * @since    1.0.0
      */
-    public function enqueue_scripts(): void {
+    public function enqueue_scripts(): void
+    {
         /**
          * This function is provided for demonstration purposes only.
          *
@@ -91,9 +96,9 @@ final class LknmpGatewayGiveWPPublic {
          * between the defined hooks and the functions defined in this
          * class.
          */
-        wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/lknmp-gateway-givewp-public.js', array('jquery'), $this->version, false );
-    
-    
+        wp_enqueue_script($this->plugin_name, plugin_dir_url(__FILE__) . 'js/lknmp-gateway-givewp-public.js', array('jquery'), $this->version, false);
+
+
         $configs = LknmpGatewayGiveWPHelper::get_configs();
         $url_pagina = site_url();
         $idUnique = uniqid();
@@ -104,7 +109,7 @@ final class LknmpGatewayGiveWPPublic {
         $MenssageErrorEmailInvalid = __('The Email field is invalid. Please enter a valid email address.', 'lknmp-gateway-givewp');
 
         $lknmp_globals = array(
-            'key' => $configs['key'], 
+            'key' => $configs['key'],
             'token' => $configs['token'],
             'pageUrl' => $url_pagina,
             'idUnique' => $idUnique,

--- a/Public/js/lknmp-gateway-givewp-public.js
+++ b/Public/js/lknmp-gateway-givewp-public.js
@@ -2,29 +2,40 @@
 	'use strict';
 
 	let mercadoPagoWindow = null
+	let lkninterval = null
 
 	document.addEventListener('DOMContentLoaded', () => {
-		let mercadoWindow = document.querySelector('iframe[title="Donation Form"').contentWindow.window
+		let mercadoIFrame = document.querySelector('iframe[title="Donation Form"')
+		if (mercadoIFrame) {
+			mercadoIFrame = mercadoIFrame.contentWindow.window
+			const originalWindowOpen = mercadoIFrame.open;
 
-		const originalWindowOpen = mercadoWindow.open;
+			document.cookie = `lkn_mercado_pago_url=empty; path=/; max-age=3600`;
 
-		document.cookie = `lkn_mercado_pago_url=empty; path=/; max-age=3600`;
+			mercadoIFrame.open = function (...args) {
+				if (Array.isArray(args) && args.length > 0) {
+					const url = args[0];
 
-		mercadoWindow.open = function (...args) {
-			if (Array.isArray(args) && args.length > 0) {
-				const url = args[0];
+					if (url && url.includes('mercadopago.com.br/checkout')) {
+						const newWindow = originalWindowOpen.apply(this, args);
+						mercadoPagoWindow = newWindow
 
-				if (url && url.includes('mercadopago.com.br/checkout')) {
-					const newWindow = originalWindowOpen.apply(this, args);
-					mercadoPagoWindow = newWindow
+						lkninterval = setInterval(() => {
+							if (mercadoPagoWindow.closed) {
+								clearInterval(lkninterval);
+								window.location.reload();
+							}
+						}, 500);
 
-					return newWindow;
+						return newWindow;
+					}
 				}
-			}
 
-			// Caso a URL não seja do MercadoPago ou args não seja um array válido, segue o comportamento normal
-			return originalWindowOpen.apply(this, args);
-		};
+				// Caso a URL não seja do MercadoPago ou args não seja um array válido, segue o comportamento normal
+				return originalWindowOpen.apply(this, args);
+			};
+		}
+
 
 		document.cookie = "lkn_payment_url=empty; path=/;";
 
@@ -41,6 +52,7 @@
 
 			if (paymentUrl !== 'empty') {
 				clearInterval(checkPaymentStatus);
+				clearInterval(lkninterval);
 				document.cookie = "lkn_payment_url=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
 				if (mercadoPagoWindow) {
 					mercadoPagoWindow.close();

--- a/Public/js/lknmp-gateway-givewp-public.js
+++ b/Public/js/lknmp-gateway-givewp-public.js
@@ -1,6 +1,57 @@
 (function ($) {
 	'use strict';
 
+	let mercadoPagoWindow = null
+
+	document.addEventListener('DOMContentLoaded', () => {
+		let mercadoWindow = document.querySelector('iframe[title="Donation Form"').contentWindow.window
+
+		const originalWindowOpen = mercadoWindow.open;
+
+		document.cookie = `lkn_mercado_pago_url=empty; path=/; max-age=3600`;
+
+		mercadoWindow.open = function (...args) {
+			if (Array.isArray(args) && args.length > 0) {
+				const url = args[0];
+
+				if (url && url.includes('mercadopago.com.br/checkout')) {
+					const newWindow = originalWindowOpen.apply(this, args);
+					mercadoPagoWindow = newWindow
+
+					return newWindow;
+				}
+			}
+
+			// Caso a URL não seja do MercadoPago ou args não seja um array válido, segue o comportamento normal
+			return originalWindowOpen.apply(this, args);
+		};
+
+		document.cookie = "lkn_payment_url=empty; path=/;";
+
+		// Função para obter o valor do cookie
+		function getCookie(name) {
+			const value = `; ${document.cookie}`;
+			const parts = value.split(`; ${name}=`);
+			if (parts.length === 2) return parts.pop().split(';').shift();
+		}
+
+		// Monitora o valor do cookie a cada 1 segundo
+		const checkPaymentStatus = setInterval(() => {
+			const paymentUrl = getCookie('lkn_payment_url');
+
+			if (paymentUrl !== 'empty') {
+				clearInterval(checkPaymentStatus);
+				document.cookie = "lkn_payment_url=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+				if (mercadoPagoWindow) {
+					mercadoPagoWindow.close();
+				}
+
+				window.location.href = decodeURIComponent(paymentUrl);
+			}
+		}, 1000);
+	});
+
+
 	function initializeMercadoPago() {
 
 		let showMP = true;
@@ -127,7 +178,7 @@
 				}
 			});
 
-			document.querySelector('input[type="submit"]').disabled = true; // Reabilita o botão de submit
+			document.querySelector('input[type="submit"]').disabled = false; // Reabilita o botão de submit
 		}
 
 		if (document.querySelector('#wallet_container')) {
@@ -138,7 +189,7 @@
 					}
 					const mp = new MercadoPago(lknmpGlobals.key);
 					const bricksBuilder = mp.bricks();
-					mp.bricks().create('wallet', 'wallet_container', {
+					bricksBuilder.create('wallet', 'wallet_container', {
 						initialization: {
 							preferenceId: preferenceID,
 							redirectMode: 'blank'

--- a/Public/js/plugin-script.js
+++ b/Public/js/plugin-script.js
@@ -4,6 +4,7 @@ let OneLoad = true;
 let showMP = true;
 let confirmPayment = false
 let buttonValue = false
+let mercadoPagoWindow = null
 
 window.onload = () => {
     buttonValue = document.querySelector('.givewp-fields-amount__level')
@@ -26,15 +27,15 @@ function renderComponentsOnce() {
     if (!hasRenderedComponents) {
         const tryRender = () => {
             criarPreferenciaDePagamento()
-                .then(preferenceID => {
+                .then(async preferenceID => {
                     if (configData.advDebug == 'enabled') {
                         console.log('ID da preferência criada:', preferenceID);
                     }
-                    preferenceID = preferenceID;
                     const mp = new MercadoPago(configData.key);
                     //TODO se houver erro 400, temos que retornar ao usuário???
                     const bricksBuilder = mp.bricks();
-                    bricksBuilder.create("wallet", "wallet_container", {
+
+                    await bricksBuilder.create("wallet", "wallet_container", {
                         initialization: {
                             preferenceId: preferenceID,
                             redirectMode: 'blank'
@@ -317,7 +318,7 @@ function checkInputs() {
     }
 
     if (nomeInput && emailInput && walletContainer) {
-        const mercadoPagoButton = document.querySelector('.svelte-h6o0kp');
+        const mercadoPagoButton = document.querySelector('button[aria-label*="Mercado Pago"]');
         const handleClick = function () {
             const messageElement = document.createElement('div');
             messageElement.textContent = lknMercadoPagoGlobals.MenssageSuccess;
@@ -330,9 +331,8 @@ function checkInputs() {
                 donationForm.appendChild(messageElement);
             }
 
-            const submitDonationButton = document.querySelector('.givewp-layouts-section button[type="submit"]');
+            let submitDonationButton = document.querySelector('.givewp-layouts-section button[type="submit"]');
             if (submitDonationButton) {
-
                 if (!confirmPayment) {
                     submitDonationButton.removeAttribute('disabled');
                     submitDonationButton.click();
@@ -365,7 +365,9 @@ function checkInputs() {
             showMP = false;
         } else {
             walletContainer.style.display = 'block';
-            warningText.textContent = '';
+            if (warningText?.textContent) {
+                warningText.textContent = '';
+            }
             showMP = true;
         }
     }


### PR DESCRIPTION
# Link Nacional Payment Gateway for MercadoPago and GiveWP

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: givewp, payment, mercadopago, card

Testado até: 6.7.2

Versão estável: 1.4.0

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil)


## Descrição

O [MercadoPago Payment Gateway for GiveWP](https://www.linknacional.com.br/wordpress/givewp/) integra perfeitamente o MercadoPago ao plugin de doações GiveWP para WordPress, proporcionando uma solução segura e eficiente para receber doações online. Este plugin suporta múltiplos métodos de pagamento, doações recorrentes e formulários de doação personalizáveis. Melhore a experiência dos seus doadores com um gateway de pagamento confiável, aumente seus esforços de arrecadação de fundos e gerencie as doações de forma simples com relatórios detalhados e uma interface amigável.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".

## Resumo(1.4.0):

> Novas páginas de feedback ao processar o pagamento.

## Sucesso:
![image](https://github.com/user-attachments/assets/69c28018-f1c8-42cf-afe4-16687a0c2507)

## Falhou:
![image](https://github.com/user-attachments/assets/6dcb8516-286e-493c-a823-04e019d3a474)

## Error/Warning:
![image](https://github.com/user-attachments/assets/9740c4eb-133f-40d3-bf28-88bf64737b82)

> Ao fechar o ambiente do `sandbox` sem processar nenhum tipo de pagamento, a página principal será atualizada automaticamente. 

> Após receber o feedback o usuário pode retornar a guia principal, onde irá fechar a guia do feedback automaticamente e encaminhará para a página de conclusão do pedido com o status atual da doação.