### PR TITLE
1.3.2 - lkn-mercadopago-for-givewp (Correção no input custom) 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: '1.3.1' # // TODO caso necessário definir a tag da release manualmente
+        custom_tag: '1.3.2' # // TODO caso necessário definir a tag da release manualmente
 
     # Generate new release
     - name: Generate new Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.2 - 21/03/2025
+* Correção no custom input.
+
 # 1.3.1 - 12/03/2025
 * Correção na conversão do valor para float.
 

--- a/Public/js/plugin-script.js
+++ b/Public/js/plugin-script.js
@@ -205,10 +205,15 @@ function observeMetodoChanges() {
         const myGateway = document.querySelector('.givewp-fields-gateways__gateway.givewp-fields-gateways__gateway--lknmp-gateway-givewp.givewp-fields-gateways__gateway--active');
 
         // Se ele estiver ativo, habilita o botão Donate Now
+        const submitButton = document.querySelector('button[type="submit"]');
         if (myGateway) {
-            document.querySelector('button[type="submit"]').disabled = true;
+            if (submitButton) {
+                submitButton.disabled = true;
+            }
         } else {
-            document.querySelector('button[type="submit"]').disabled = false;
+            if (submitButton) {
+                submitButton.disabled = false;
+            }
             hasRenderedComponents = false;
         }
         updateDonationAmount();

--- a/Public/js/plugin-script.js
+++ b/Public/js/plugin-script.js
@@ -6,20 +6,31 @@ let confirmPayment = false
 let buttonValue = false
 
 window.onload = () => {
-    buttonValue = document.querySelector('.givewp-fields-amount__level')
-    if (buttonValue) {
-        buttonValue = buttonValue.textContent
-    }
+    const observer = new MutationObserver((mutationsList, observer) => {
+        const customInput = document.getElementById('amount-custom');
 
-    const customInput = document.getElementById('amount-custom');
+        if (customInput) {
+            customInput.addEventListener('input', () => {
+                let value = customInput.value;
 
-    customInput.addEventListener('input', () => {
-        let value = customInput.value;
+                if (value.slice(-1) === '.' || value.slice(-1) === ',') {
+                    customInput.value = value.slice(0, -1);
+                }
+            });
+        }
 
-        if (value.slice(-1) === '.' || value.slice(-1) === ',') {
-            customInput.value = value.slice(0, -1);
+        const buttonFormValue = document.querySelector('.givewp-fields-amount__level');
+        if (buttonFormValue) {
+            buttonValue = buttonFormValue.textContent;
+
+            observer.disconnect();
         }
     });
+
+    const config = { childList: true, subtree: true };
+
+    // Começa a observar o `document.body`
+    observer.observe(document.body, config);
 };
 
 function renderComponentsOnce() {

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/givewp/
 Tags: givewp, payment, mercadopago, card
 Requires at least: 5.7
 Tested up to: 6.7
-Stable tag: 1.3.1
+Stable tag: 1.3.2
 Requires PHP: 7.4
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/README.txt
+++ b/README.txt
@@ -84,6 +84,9 @@ The Link Nacional MercadoPago for GiveWP plugin is now live and working.
 
 == Changelog ==
 
+= 1.3.2 = *2025/03/21*
+* Fix in custom input.
+
 = 1.3.1 = *2025/03/12*
 * Fix in the conversion of the value to float.
 

--- a/lknmp-gateway-givewp.php
+++ b/lknmp-gateway-givewp.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * The plugin bootstrap file
  *
@@ -16,7 +17,7 @@
  * Requires Plugins:  give
  * Plugin URI:        https://www.linknacional.com.br/wordpress/givewp/
  * Description:       Gateway de pagamento Mercado Pago integrado ao plugin de doações GiveWP no WordPress.
- * Version:           1.3.1
+ * Version:           1.3.2
  * Author:            Link Nacional
  * Author URI:        https://www.linknacional.com.br/wordpress/givewp//
  * License:           GPL-3.0+
@@ -42,7 +43,7 @@ use Lknmp\Gateway\Includes\LknmpGatewayGiveWPDeactivator;
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('LKNMP_GATEWAY_GIVEWP_VERSION')) {
-    define('LKNMP_GATEWAY_GIVEWP_VERSION', '1.3.1');
+    define('LKNMP_GATEWAY_GIVEWP_VERSION', '1.3.2');
 }
 
 if (! defined('LKNMP_GATEWAY_MIN_GIVE_VERSION')) {


### PR DESCRIPTION
# Link Nacional MercadoPago Payment Gateway for GiveWP

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: givewp, payment, mercadopago, card

Testado até: 6.7

Versão estável: 1.3.2

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil)

## Descrição

O [MercadoPago Payment Gateway for GiveWP](https://www.linknacional.com.br/wordpress/givewp/) integra perfeitamente o MercadoPago com o plugin de doações GiveWP para WordPress, fornecendo uma solução segura e eficiente para receber doações online. Este plugin suporta múltiplos métodos de pagamento, doações recorrentes e formulários de doação personalizáveis. Melhore a experiência dos seus doadores com um gateway de pagamento confiável, aumente seus esforços de arrecadação de fundos e gerencie as doações de forma simples com relatórios detalhados e uma interface amigável.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin GiveWP também está ativado.

## Resumo(1.3.2):

> Correção na custom input em outros modelos de formulário. 
