### PR TITLE
1.4.1 - lkn-mercadopago-for-givewp (Correção no script do cache)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: '1.4.0' # // TODO caso necessário definir a tag da release manualmente
+        custom_tag: '1.4.1' # // TODO caso necessário definir a tag da release manualmente
 
     # Generate new release
     - name: Generate new Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.4.1 - 02/04/2025
+* Erro na obtenção do cache através do script .
+
 # 1.4.0 - 25/03/2025
 * Páginas de feedback para o ambiente de sandbox do MercadoPago.
 

--- a/Public/js/lknmp-gateway-givewp-public.js
+++ b/Public/js/lknmp-gateway-givewp-public.js
@@ -178,7 +178,9 @@
 				newButton.style.display = 'none';
 			}
 
-			fieldset.appendChild(newButton);
+			if (fieldset) {
+				fieldset.appendChild(newButton);
+			}
 
 			const mp = new MercadoPago(lknmpGlobals.key);
 			const bricksBuilder = mp.bricks();

--- a/Public/js/lknmp-gateway-givewp-public.js
+++ b/Public/js/lknmp-gateway-givewp-public.js
@@ -3,10 +3,12 @@
 
 	let mercadoPagoWindow = null
 	let lkninterval = null
+	let contentMercadoIFrame = null
 
 	document.addEventListener('DOMContentLoaded', () => {
 		let mercadoIFrame = document.querySelector('iframe[title="Donation Form"')
 		if (mercadoIFrame) {
+			contentMercadoIFrame = mercadoIFrame
 			mercadoIFrame = mercadoIFrame.contentWindow.window
 			const originalWindowOpen = mercadoIFrame.open;
 
@@ -46,21 +48,23 @@
 			if (parts.length === 2) return parts.pop().split(';').shift();
 		}
 
-		// Monitora o valor do cookie a cada 1 segundo
-		const checkPaymentStatus = setInterval(() => {
-			const paymentUrl = getCookie('lkn_payment_url');
+		if (contentMercadoIFrame) {
+			// Monitora o valor do cookie a cada 1 segundo
+			const checkPaymentStatus = setInterval(() => {
+				const paymentUrl = getCookie('lkn_payment_url');
 
-			if (paymentUrl !== 'empty') {
-				clearInterval(checkPaymentStatus);
-				clearInterval(lkninterval);
-				document.cookie = "lkn_payment_url=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
-				if (mercadoPagoWindow) {
-					mercadoPagoWindow.close();
+				if (paymentUrl !== 'empty') {
+					clearInterval(checkPaymentStatus);
+					clearInterval(lkninterval);
+					document.cookie = "lkn_payment_url=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+					if (mercadoPagoWindow) {
+						mercadoPagoWindow.close();
+					}
+
+					window.location.href = decodeURIComponent(paymentUrl);
 				}
-
-				window.location.href = decodeURIComponent(paymentUrl);
-			}
-		}, 1000);
+			}, 1000);
+		}
 	});
 
 

--- a/Public/js/plugin-script.js
+++ b/Public/js/plugin-script.js
@@ -284,7 +284,9 @@ function observeDonationChanges() {
                         newButton.style.display = 'none';
                     }
 
-                    fieldset.appendChild(newButton);
+                    if (fieldset) {
+                        fieldset.appendChild(newButton);
+                    }
 
                     const mp = new MercadoPago(configData.key);
                     const bricksBuilder = mp.bricks();

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/givewp/
 Tags: givewp, payment, mercadopago, card
 Requires at least: 5.7
 Tested up to: 6.7
-Stable tag: 1.4.0
+Stable tag: 1.4.1
 Requires PHP: 7.4
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -83,6 +83,9 @@ The Link Nacional MercadoPago for GiveWP plugin is now live and working.
 1. Nothing yet.
 
 == Changelog ==
+
+= 1.4.1 = *2025/04/02*
+* Error retrieving cache through the script.
 
 = 1.4.0 = *2025/03/19*
 * Feedback pages for the MercadoPago sandbox environment.

--- a/lknmp-gateway-givewp.php
+++ b/lknmp-gateway-givewp.php
@@ -17,7 +17,7 @@
  * Requires Plugins:  give
  * Plugin URI:        https://www.linknacional.com.br/wordpress/givewp/
  * Description:       Gateway de pagamento Mercado Pago integrado ao plugin de doações GiveWP no WordPress.
- * Version:           1.4.0
+ * Version:           1.4.1
  * Author:            Link Nacional
  * Author URI:        https://www.linknacional.com.br/wordpress/givewp//
  * License:           GPL-3.0+
@@ -43,7 +43,7 @@ use Lknmp\Gateway\Includes\LknmpGatewayGiveWPDeactivator;
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('LKNMP_GATEWAY_GIVEWP_VERSION')) {
-    define('LKNMP_GATEWAY_GIVEWP_VERSION', '1.4.0');
+    define('LKNMP_GATEWAY_GIVEWP_VERSION', '1.4.1');
 }
 
 if (! defined('LKNMP_GATEWAY_MIN_GIVE_VERSION')) {


### PR DESCRIPTION
# Link Nacional MercadoPago Payment Gateway for GiveWP

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: givewp, payment, mercadopago, card

Testado até: 6.7

Versão estável: 1.4.1

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil)

## Descrição

O [MercadoPago Payment Gateway for GiveWP](https://www.linknacional.com.br/wordpress/givewp/) integra perfeitamente o MercadoPago com o plugin de doações GiveWP para WordPress, fornecendo uma solução segura e eficiente para receber doações online. Este plugin suporta múltiplos métodos de pagamento, doações recorrentes e formulários de doação personalizáveis. Melhore a experiência dos seus doadores com um gateway de pagamento confiável, aumente seus esforços de arrecadação de fundos e gerencie as doações de forma simples com relatórios detalhados e uma interface amigável.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin GiveWP também está ativado.

## Resumo(1.4.1):

> Correção no script do cache durante uma doação. 
