### PR TITLE
1.5.0 - lkn-mercadopago-for-givewp (Novo script para gerar o botão)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         mkdir -p dist
         mkdir -p build
-        mv ./Admin ./Includes ./Languages ./Public *.php *.txt ./build
+        mv ./Admin ./Includes ./languages ./Public *.php *.txt ./build
         cp -r vendor build/vendor
         find ./build -type f -exec chmod 0644 {} +
         find ./build -type d -exec chmod 0755 {} +


### PR DESCRIPTION
# Link Nacional MercadoPago Payment Gateway for GiveWP

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: givewp, payment, mercadopago, card

Testado até: 6.7

Versão estável: 1.5.0

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil)

## Descrição

O [MercadoPago Payment Gateway for GiveWP](https://www.linknacional.com.br/wordpress/givewp/) integra perfeitamente o MercadoPago com o plugin de doações GiveWP para WordPress, fornecendo uma solução segura e eficiente para receber doações online. Este plugin suporta múltiplos métodos de pagamento, doações recorrentes e formulários de doação personalizáveis. Melhore a experiência dos seus doadores com um gateway de pagamento confiável, aumente seus esforços de arrecadação de fundos e gerencie as doações de forma simples com relatórios detalhados e uma interface amigável.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin GiveWP também está ativado.

## Resumo(1.5.0):

> Novo script para gerar o botão do MercadoPago:
![image](https://github.com/user-attachments/assets/09cf5ac1-5566-4709-86ee-379f61e1d0be)


